### PR TITLE
Added support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "laravel/passport": "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-    "laravel/socialite": "^3.0 || ^4.0",
+    "laravel/passport": "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
+    "laravel/socialite": "^3.0 || ^4.0 || ^5.0",
     "illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0",
     "league/oauth2-server": "^6.0 || ^7.0 || ^8.0"
   },


### PR DESCRIPTION
Just updating some dependencies version required to use with Laravel 8.
The problem was with "illuminate/support" package. The package "laravel/passport v9.0" uses "illuminate/support ^7.0", but "laravel/framework" needs ^7.0.
Similar issue with "laravel/socialite".